### PR TITLE
Update InfoNES.cpp

### DIFF
--- a/infones/InfoNES.cpp
+++ b/infones/InfoNES.cpp
@@ -741,7 +741,9 @@ int __not_in_flash_func(InfoNES_HSync)()
       InfoNES_DrawLine();
      
     } else {
-      InfoNES_MemorySet(WorkLine, 0, 640);
+      // Array out of bounds, WorkLine size is equals to NES_DISP_WIDTH << 1 = 512
+      //InfoNES_MemorySet(WorkLine, 0, 640);
+      InfoNES_MemorySet(WorkLine, 0, NES_DISP_WIDTH << 1);
     }
      InfoNES_PostDrawLine(PPU_Scanline, false);
     //  if (PPU_Scanline >=240) {


### PR DESCRIPTION
I found a memory issue. The memory after line buffer get wrong values. The root cause is that 320 pixels display width is suggested for cleanup while buffer has 256 pixels